### PR TITLE
Fix build failure

### DIFF
--- a/www-client/brave-browser-beta/brave-browser-beta-1.84.111.ebuild
+++ b/www-client/brave-browser-beta/brave-browser-beta-1.84.111.ebuild
@@ -88,7 +88,7 @@ src_install() {
 	cd "${ED}" || die
 	unpacker
 
-	rm -r etc usr/share/menu || die
+	rm -rf etc usr/share/menu || die
 	mv usr/share/doc/${PN} usr/share/doc/${PF} || die
 
 	gzip -d usr/share/doc/${PF}/changelog.gz || die


### PR DESCRIPTION
`usr/share/menu` doesn't seem to exist in this version